### PR TITLE
Overwrite blog posts publication date

### DIFF
--- a/docs/blog/.template/index.md
+++ b/docs/blog/.template/index.md
@@ -2,6 +2,7 @@
 title: Title of the post
 description: Short description (3-5 sentences) that will attract the readers to read this post.
 author: Author Name
+publicationDate: dd.mm.yyyy
 tags:
   - WebSight # Choose from the list of existing tags or add new
   - AWS
@@ -9,6 +10,8 @@ tags:
   - Sling
   - DXP
 ---
+
+*Published at: dd.mm.yyyy by [Author Name](https://github.com/author-git-slug)*
 
 Content of your blog goes here
 

--- a/docs/blog/2022/building-osgi-apps-with-sling-feature-model/index.md
+++ b/docs/blog/2022/building-osgi-apps-with-sling-feature-model/index.md
@@ -2,11 +2,14 @@
 title: Building OSGi applications with Sling Feature Model
 description: In this article, you will learn how we can benefit from OSGi modularity and Sling Feature Model.
 author: Tomasz Michalak
+publicationDate: 15.07.2022
 tags:
   - WebSight
   - OSGi
   - Sling Feature Model
 ---
+
+*Published at: 15.07.2022 by [Tomasz Michalak](https://github.com/tomaszmichalak)*
 
 > Living in a city, we care about the streets and parks inside it. However, the city is not something permanent. It is constantly changing within its borders. City planners should replan internal city roads easily, adapting them to new requirements. However, for provincial and municipal roads, all changes should be approved by the provincial executive planners. 
 > The same rules are valid in IT. As long as we change our private functions, the impact on the overall system is low. However, by changing module interfaces, we can break other modules. We expect a mechanism to define and constantly validate our national, provincial, city and private application roads.

--- a/docs/blog/2022/on-the-road-to-the-perfect-dxp/index.md
+++ b/docs/blog/2022/on-the-road-to-the-perfect-dxp/index.md
@@ -2,10 +2,13 @@
 title: On the road to the perfect DXP
 description: The Past, the present, and the future of the CMS and DXP platforms. I will describe the evolution from WordPress to cloud-native emerging solutions, with an accent on enterprise-grade systems. 
 author: Michał Cukierman
+publicationDate: 01.07.2022
 tags:
   - WebSight
   - DXP
 ---
+
+*Published at: 01.07.2022 by [Michał Cukierman](https://github.com/michalcukierman)*
 
 ## THE PROBLEM
 It is very easy to get lost when it comes to choosing the technology stack driving your digital projects. It may be surprising, but WordPress, Joomla, and Drupal are still the most popular options for small and medium companies. Larger ones often choose full-flagged DXPs like Adobe Experience Manager, Sitecore, or Magnolia to fulfill their enterprise needs. All of the solutions above are mature and battle-tested, they adapt to changing world but still use best practices from previous decades.

--- a/docs/blog/2022/shipping-and-developing-osgi-application-in-container/index.md
+++ b/docs/blog/2022/shipping-and-developing-osgi-application-in-container/index.md
@@ -2,12 +2,15 @@
 title: Why we decided to ship and develop the OSGi application in containers
 description: In this article, I will point out five reasons we use containers to develop and ship OSGi Sling-based applications.
 author: Maciej Laskowski
+publicationDate: 02.08.2022
 tags:
   - WebSight
   - Containers
   - Docker
   - Sling
 ---
+
+*Published at: 02.08.2022 by [Maciej Laskowski](https://github.com/malaskowski)*
 
 > Modern distributed software systems consist of multiple cooperating software applications. However, to run the application, the software we develop is only one part. The second one is the environment (e.g., JVM and OS). In this article, I will focus on building an OSGi application and explain five benefits we gained thanks to containerizing it.
 

--- a/docs/blog/tags.md
+++ b/docs/blog/tags.md
@@ -1,1 +1,0 @@
-{{ tag_content }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,10 +69,6 @@ plugins:
       dirs:
         - blog/2022
       template: theme/ws-blog.html
-      features:
-        tags:
-          index_page: blog/tags.md
-          insert: bottom
   - redirects:
       redirect_maps:
           'getting-started/index.md': 'getting-started/quick-start/index.md'

--- a/theme/ws-blog.html
+++ b/theme/ws-blog.html
@@ -13,14 +13,10 @@
         <a class="link" href="{{ url }}">{{ title }}</a>
     </h3>
     <div class="blog-post-extra">
-        {{ ("Updated" if is_revision else "Published") + " at: " + time }}
+        {{ "Published at: " + page.meta.publicationDate }}
         by {{page.meta["author"] if "author" in page.meta else "" }}
 
     </div>
-    {% if show_tags and "tags" in page.meta %}
-    {% call render_tags(page.meta["tags"], index_url) %}
-    {% endcall %}
-    {% endif %}
     <p class="blog-post-description">
         {{ description }}
     </p>


### PR DESCRIPTION
## Motivation
- [mkdocs-blogging-plugin](https://github.com/liang2kl/mkdocs-blogging-plugin) prints publication date which is created from the git log last commit of the document
- GH Pages mechanism base on committing documents to the special branch every time the page is generated
- With this unfortunate combo, blog posts of websight.io are "published" every time page is published

This pull request contains "workaround" for displaying proper publication dates despite of the behaviour explained above.