### PR TITLE
WebSight CMS release 1.1.0 - htl cache issue notice cleanup

### DIFF
--- a/docs/docs/developers/create-and-develop-project/index.md
+++ b/docs/docs/developers/create-and-develop-project/index.md
@@ -425,10 +425,6 @@ This is how the new component definition looks in the codebase. Deploy the chang
 
 ![](img35.png)
 
-!!! Info "Note"
-If you are using WebSight CMS version older than 1.1.0: After redeployment and change of HTML the cache of the script needs to be cleaned manually via http://localhost:8080/system/console/scriptcache to see the changes, use the Clear Cache button at the bottom - this issue is fixed since WebSight CMS CE 1.1.0.
-
-
 New component is available now in editor and can be added to the page. If text is not configured via dialog, nothing is rendered because of the data-sly-test statement in the component renderer. If nothing is rendered by component the placeholder is displayed automatically in the editor. Edit action can be used to open dialog and use rich text dialog input to configure the text.
 
 ![](img36.png)

--- a/docs/docs/developers/quick-start/index.md
+++ b/docs/docs/developers/quick-start/index.md
@@ -311,10 +311,6 @@ Submit changes. The title should look like expected now. You can delete the orig
 
 ![Updated Luna Title](luna-title-updated.png)
 
-!!! info "Hint"
-If you are using WebSight CMS version older than 1.1.0: If there are no visual changes than probably HTL script was cached. You should go to [http://localhost:8080/system/console/scriptcache](http://localhost:8080/system/console/scriptcache) and clear cache - this issue is fixed since WebSight CMS CE 1.1.0.
-
-
 ## Part F: Clean-up
 
 ### Stop the environment


### PR DESCRIPTION
This PR should be merged after some time after CMS 1.1.0 release where this issue was fixed (11.10) because somebody still might be using CMS 1.0.0 so let's keep the notice for about 1 month.