### PR TITLE
Change foreground color for better contrast

### DIFF
--- a/theme/assets/stylesheets/home.css
+++ b/theme/assets/stylesheets/home.css
@@ -116,6 +116,7 @@
 
 :root {
   --md-parallax-perspective: 2.5rem;
+  --md-default-fg-color--light: #6a6a6a;
 }
 
 .mdx-parallax {


### PR DESCRIPTION
The theme's default setting for the variable was a bit too light, not meeting minimum contrast standard for small text.	

This PR changes the variable to something easier to read, while keeping the design harmony.

### Before
![image](https://user-images.githubusercontent.com/9519976/197990576-5d3ed4c7-c863-427b-8dc2-88dbe36f8aa8.png)

### After
![image](https://user-images.githubusercontent.com/9519976/197990612-4f5253d9-048e-4b0b-bae8-836cbbd31396.png)


### Before
![image](https://user-images.githubusercontent.com/9519976/197990284-3e33fbae-f856-4fa0-9900-e0dc74158610.png)

### After
![image](https://user-images.githubusercontent.com/9519976/197990433-89c3ed90-2a2a-4fc5-963d-76125dccb4e0.png)
