### PR TITLE
layouts renamed to building blocks

### DIFF
--- a/docs/cms/developers/components/index.md
+++ b/docs/cms/developers/components/index.md
@@ -210,7 +210,10 @@ Use the following resource properties to define the component:
             - must contain other components to be usable <br> 
             - contain no logic (other than logic related to layout calculation) <br> 
             - interact only on page resize (no other “user actions” allowed) <br> 
+            - have no visible UI elements (like texts) <br>
             - have no visible UI elements (like texts)<br> <br>
+
+            To implement a building block component use the <code>instanceResourceType</code> component definition property and define the component template. <br> <br>
 
             Examples of building block: <br>
             - Hero sections (containers including texts, images, etc dedicated to be used at the top section of the page) <br>

--- a/docs/cms/developers/components/index.md
+++ b/docs/cms/developers/components/index.md
@@ -198,25 +198,27 @@ Use the following resource properties to define the component:
         </td>
     </tr>
     <tr>
-        <td>isLayout</td>
+        <td>isBuildingBlock</td>
         <td>No</td>
         <td>boolean, false by default</td>
-        <td>Defines the component as a layout component.
-            Layout components are displayed in a separate section in the WebSight CMS pages editor from components that are not layout components. <br> <br>
+        <td>Defines the component as a building block component.
+            Building block components are displayed in a separate section in the WebSight CMS pages editor from components that are not building block components. <br> <br>
 
-            It’s up to the component developer to set <code>isLayout=true</code>, but the guideline is to use it for components that: <br> 
-            - are used to define page layout <br>
+            It’s up to the component developer to set <code>isBuildingBlock=true</code>, but the guideline is to use it for components that: <br> 
+            - are used to speed up page content creation process <br>
+            - create components instances in specific layout and initial setup <br>
             - must contain other components to be usable <br> 
             - contain no logic (other than logic related to layout calculation) <br> 
             - interact only on page resize (no other “user actions” allowed) <br> 
             - have no visible UI elements (like texts)<br> <br>
 
-            Examples of Layouts: <br>
-            - 2-column container <br>
-            - 1-column container <br>
+            Examples of building block: <br>
+            - Hero sections (containers including texts, images, etc dedicated to be used at the top section of the page) <br>
+            - 4 columns paragraph (container including title and containers for 4 columns with title + RTE in each) <br>
             - Section with title, image, text and CTA (container including components) <br> <br>
 
             Example of components that are not Layouts: <br>
+            - 2-columns, 3-columens, etc, empty containers setup - containers should contain components allowing to set content to be useful building block <br>
             - image, title or CTA, all of which have visible UI elements (like texts) <br>
             - logo cloud, which contain very specific CSS logic and should not be used to create generic page layouts) <br>
             - Accordion, which contains logic not related to layout calculation <br>


### PR DESCRIPTION
To be merged after update in CMS. 
We should update also images with the editor after UI update and other references to layouts, like https://docs.websight.io/cms/authors/component-libs/howlite/layouts/